### PR TITLE
Makefile fix (Replace tab with space), savetool fix C warnings, improve readme

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-ifeq ($(strip $(DEVKITARM)),)
-	$(error "Please set DEVKITARM in your environment. export DEVKITARM=<path to>devkitARM")
+ifndef DEVKITARM
+       $(error "Please set DEVKITARM in your environment. export DEVKITARM=<path to>devkitARM")
 endif
 
 ## ======================

--- a/README.md
+++ b/README.md
@@ -1,15 +1,25 @@
+# oot3dhax
 This is a 3DS savedata exploit for "The Legend of Zelda: Ocarina of Time 3D". Hence the datetime displayed for the save-slot, this haxx has existed since October 2012. The following regions are supported: USA, EUR, and JPN. Since the gamecard(there's only one "version" of the main CXI used for the gamecard) and eShop versions of the game are basically identical, the exploit can be used with both(if one can get the exploit savedata written to the save-image used by the target game version of course).  
 
 This savegame haxx is the same one referred to here: http://3dbrew.org/wiki/5.0.0-11  
 
 For details on the vuln/etc, see source and here: http://3dbrew.org/wiki/3DS_Userland_Flaws
 
-Haxx usage: 1) goto the save-slot select screen 2) select haxx save-saveslot 3) begin loading the save-slot 4) wait for the game to finish loading 5) either press A, do anything triggering display of dialogs, or press any button on the touch-screen(the VIEW button, the MAP button, and the buttons for the currently equipped items don't trigger it).  
-  
-There's two build methods: build the savefiles then write those to the savedata FS via other methods(recommended), such as ctrclient-yls8. Or build the savefiles + generate a save with 3dsfuse then update the AESMAC(see Makefile, requires a tool for actually calculating the AESMAC).  
+### Haxx usage
+1. Goto the save-slot select screen
+2. Select haxx save-saveslot 
+3. Begin loading the save-slot
+4. Wait for the game to finish loading
+5. Either press A, do anything triggering display of dialogs, or press any button on the touch-screen(the VIEW button, the MAP button, and the buttons for the currently equipped items don't trigger it).  
 
-Make command: "make EXECHAX={value} FWVER={value}" FWVER should be any value >=0x25 for system-version >=v5.0 with EXECHAX=2, value 0x1F otherwise.  
-Build oot3d_savetool with the following: gcc -o oot3d_savetool oot3d_savetool.c  
+### Build methods
+There's two build methods:
+* Build the savefiles then write those to the savedata FS via other methods (recommended), such as ctrclient-yls8.
+* Build the savefiles + generate a save with 3dsfuse then update the AESMAC (see Makefile, requires a tool for actually calculating the AESMAC).  
+
+Make command: 
+"make EXECHAX={value} FWVER={value}"
+FWVER should be any value >=0x25 for system-version >=v5.0 with EXECHAX=2, value 0x1F otherwise.  
 
 EXECHAX values(see also http://3dbrew.org/wiki/3DS_System_Flaws):
 * 0 for arm9 pxips9hax(fixed with v5.0).
@@ -25,4 +35,3 @@ For reading/writing the savefile(this can be any save0X.bin file) with ctrclient
 * Write save00.bin:   ctrclient-yls8 --serveradr={ipadr} "--customcmd=directfilerw 0x567890B1 0x1 0x1 0x4 0x18 0x7 0x14dc 0x0 2F007300610076006500300030002E00620069006E000000 @input.bin"
 * Write payload.bin:  ctrclient-yls8 --serveradr={ipadr} "--customcmd=directfilerw 0x567890B1 0x1 0x1 0x4 0x1a 0x7 {payloadsize} 0x0 2F007000610079006C006F00610064002E00620069006E000000 @payload.bin"
 * Read payload.bin:   ctrclient-yls8 --serveradr={ipadr} "--customcmd=directfilerw 0x567890B1 0x1 0x1 0x4 0x1a 0x1 0x0 2F007000610079006C006F00610064002E00620069006E000000 @out.bin"
-

--- a/oot3d_savetool.c
+++ b/oot3d_savetool.c
@@ -113,7 +113,6 @@ void process_systemdat(unsigned char *buf)
 int main(int argc, char **argv)
 {
 	FILE *f;
-	int i;
 	unsigned short calc_crc=0, save_calc=0;
 	unsigned int crc_off = 0x14d8;
 	int updatesave = 0;
@@ -157,7 +156,7 @@ int main(int argc, char **argv)
 
 	f = fopen(argv[1], "rb");
 	if(f==NULL)return 0;
-	if(fread(&savegame, 1, filestat.st_size, f) != filestat.st_size)
+	if(fread(&savegame, 1, filestat.st_size, f) != (size_t)filestat.st_size)
 	{
 		printf("Read failed.\n");
 		fclose(f);
@@ -203,7 +202,7 @@ int main(int argc, char **argv)
 		printf("Failed to open savegame for writing.\n");
 		return 0;
 	}
-	if(fwrite(&savegame, 1, filestat.st_size, f) != filestat.st_size)
+	if(fwrite(&savegame, 1, filestat.st_size, f) != (size_t)filestat.st_size)
 	{
 		printf("Write failed.\n");
 		fclose(f);


### PR DESCRIPTION
Makefile :
The 2nd line start by tabulation and make interpret it as target execution.
C warnings :
Unused i variable.
Comparaison between unsigned and signed value.
Readme :
Better presentation.