### PR TITLE
Fixed typographical error, changed arbitary to arbitrary in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ EXECHAX values(see also http://3dbrew.org/wiki/3DS_System_Flaws):
 * 2 for GSP arm11code-loading haxx.
 * 3 for arm9hax with AM(fixed with v5.0).
 
-The arm11-code uses gxcmd4 to load "/payload.bin" from the savedata FS to process-address 0x00101000 for execution, see source(filesize can be arbitary).  
+The arm11-code uses gxcmd4 to load "/payload.bin" from the savedata FS to process-address 0x00101000 for execution, see source(filesize can be arbitrary).  
 The arm9-code loads a payload from SD card, see source.  
 
 For reading/writing the savefile(this can be any save0X.bin file) with ctrclient-yls8, for gamecard:


### PR DESCRIPTION
@yellows8, I've corrected a typographical error in the documentation of the [oot3dhax](https://github.com/yellows8/oot3dhax) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.